### PR TITLE
Fix possible infinite loop

### DIFF
--- a/src/encoding.c
+++ b/src/encoding.c
@@ -382,7 +382,7 @@ static int combine_shards_internal(
     uint8_t group_shares[secret_len * (group_threshold + 1)];
     uint8_t *group_share = group_shares;
 
-    for(uint8_t i = 0; !error && i < next_group; ++i) {
+    for(uint8_t i = 0; !error && i < (uint8_t) next_group; ++i) {
         sskr_group* g = &groups[i];
 
         gx[i] = g->group_index;


### PR DESCRIPTION
Hi,

I am not sure why the `next_group` variable is defined as type `size_t` but `next_group` is being compared to a `uint8_t` in a loop condition. This causes CodeQL to give a high severity security warning. '*High Severity*' is probably a bit alarmist but in a loop condition, comparison of a value of a narrow type with a value of a wide type may result in unexpected behavior if the wider value is sufficiently large (or small). This is because the narrower value may overflow. This can lead to an infinite loop.

See here for further explanation of the warning:
[Comparison of narrow type with wide type in loop condition](https://codeql.github.com/codeql-query-help/cpp/cpp-comparison-with-wider-type/)

This PR  fixes #19 by casting `next_group` to `uint8_t` ensuring comparision of same types. If type casting is not the solution then maybe `next_group` should be declared as `uint8_t` not `size_t`?

Note: I chose to cast `next_group` to the narrower `uint8_t` rather than declaring `i` as the wider `size_t` as I think `next_group` *should* never be bigger than 255.