### PR TITLE
Added CodeQL scan and Clang Static Analyzer to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,68 @@
-name: ci
+name: Compilation & Tests
 on: [push, pull_request]
 jobs:
-  build-MacOS:
+  build-macos:
+    name: Build on MacOS
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: brew install cppcheck
-    - run: git clone https://github.com/BlockchainCommons/bc-crypto-base.git && cd bc-crypto-base && ./configure && make && sudo make install
-    - run: git clone https://github.com/BlockchainCommons/bc-shamir.git && cd bc-shamir && ./configure && make && sudo make install
-    - run: ./configure
-    - run: make lint
-    - run: make check
-    - run: sudo make install
-    - run: make distcheck && make distclean
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install cppcheck
+        run: brew install cppcheck
+      - name: Install bc-crypto-base
+        run: |
+          cd deps/bc-crypto-base
+          ./configure
+          make
+          sudo make install
+      - name: Install bc-shamir
+        run: |
+          cd deps/bc-shamir
+          ./configure
+          make
+          sudo make install
+      - name: Analyse bc-sskr
+        run: |
+          ./configure
+          make lint
+      - name: Test bc-sskr
+        run: make check
+      - name: Install bc-sskr
+        run: sudo make install
+      - name: Check bc-sskr distribution
+        run: |
+          make distcheck
+          make distclean
 
-  build-Linux:
-    runs-on: ubuntu-18.04
+  build-linux:
+    name: Build on Linux
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - run: git clone https://github.com/BlockchainCommons/bc-crypto-base.git && cd bc-crypto-base && ./configure && make && sudo make install
-    - run: git clone https://github.com/BlockchainCommons/bc-shamir.git && cd bc-shamir && ./configure && make && sudo make install
-    - run: ./configure && make check
-    - run: sudo make install
-    - run: make distcheck && make distclean
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install bc-crypto-base
+        run: |
+          cd deps/bc-crypto-base
+          ./configure
+          make
+          sudo make install
+      - name: Install bc-shamir
+        run: |
+          cd deps/bc-shamir
+          ./configure
+          make
+          sudo make install
+      - name: Test bc-sskr
+        run: |
+          ./configure
+          make check
+      - name: Install bc-sskr
+        run: sudo make install
+      - name: Check bc-sskr distribution
+        run: |
+          make distcheck
+          make distclean

--- a/.github/workflows/static_anlyzer.yml
+++ b/.github/workflows/static_anlyzer.yml
@@ -1,0 +1,80 @@
+name:  Static Analysis
+on: [push, pull_request]
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      pull-requests: read
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: cpp
+          queries: security-and-quality
+          debug: true
+      - name: Install bc-crypto-base
+        run: |
+          cd deps/bc-crypto-base
+          ./configure
+          make
+          sudo make install
+      - name: Install bc-shamir
+        run: |
+          cd deps/bc-shamir
+          ./configure
+          make
+          sudo make install
+      # CodeQL will create the database during the compilation
+      - name: Build bc-sskr
+        run: |
+          ./configure
+          make
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+  scan_build:
+    name: Clang Static Analyzer
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      statuses: write
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Install clang-tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install clang-tools
+      - name: Install bc-crypto-base
+        run: |
+          cd deps/bc-crypto-base
+          ./configure
+          make
+          sudo make install
+      - name: Install bc-shamir
+        run: |
+          cd deps/bc-shamir
+          ./configure
+          make
+          sudo make install
+      - name: Configure bc-sskr
+        run: |
+          scan-build ./configure
+      - name: Build with Clang Static Analyzer
+        run: |
+          make clean
+          scan-build --keep-cc -analyze-headers -enable-checker security -enable-checker unix -enable-checker valist -sarif -o output-scan-build --status-bugs make lib
+      - name: Upload scan result
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: output-scan-build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 * <img src="https://github.com/BlockchainCommons/crypto-commons/blob/master/images/logos/crypto-commons-super-simple.png" width=16 valign="bottom">&nbsp;&nbsp; ***part of the [crypto commons](https://github.com/BlockchainCommons/crypto-commons/blob/master/README.md) technology family***
 
+[![Compilation & Tests](https://github.com/BlockchainCommons/bc-sskr/actions/workflows/ci.yml/badge.svg)](https://github.com/BlockchainCommons/bc-sskr/actions/workflows/ci.yml)
+[![Static Analysis](https://github.com/BlockchainCommons/bc-sskr/actions/workflows/static_anlyzer.yml/badge.svg)](https://github.com/BlockchainCommons/bc-sskr/actions/workflows/static_anlyzer.yml)
+
 **Blockchain Commons SSKR** is an implementation of [Sharded Secret Key Reconstruction (SSKR)](https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-011-sskr.md) for use in [Blockchain Commons](https://www.BlockchainCommons.com) Software Projects.
 
 ## Prerequisites


### PR DESCRIPTION
Hi,

The issues discussed in #18, #19, #20  and #21 were discovered by using CodeQL security scanning and the Clang Static Analyzer. This PR adds two workflows to automatically perform CodeQL and Clang Static Analyzer scans on  [bc-sskr](https://github.com/BlockchainCommons/bc-sskr).

CodeQL security scan results can be seen in the "Security" tab of the this repo.

If this PR is of any use then similar can be done for [bc-shamir](https://github.com/BlockchainCommons/bc-shamir).

Note: This PR does not make any changes to code.

In future I may look to outputing the Clang Static Analyzer ourput in SARIF format and uploading to GitHub:
See here: https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github

Then all analyzer output can be viewed and managed in one place on the Security page of the repo.